### PR TITLE
Add checkbox for allowing invalid SSL certificates on the api 

### DIFF
--- a/restCallBuildTask/Engine/restCall.ts
+++ b/restCallBuildTask/Engine/restCall.ts
@@ -10,7 +10,8 @@ export module Engine{
 			this._outputFilePath = outputFilePath;	
 		}
 
-		call(webServiceUrl: string, httpVerb: string, body: string, useBasicAuthentication: Boolean, username: string, password: string, contentType:string, timeout: number){
+		call(webServiceUrl: string, httpVerb: string, body: string, useBasicAuthentication: Boolean, username: string, password: string, contentType:string, timeout: number, allowInvalidSSLCertificate: Boolean){
+			let useStrictSSL = !allowInvalidSSLCertificate
 			if(useBasicAuthentication){
 				request({
 					uri: webServiceUrl,
@@ -24,7 +25,8 @@ export module Engine{
 						user: username,
 						pass: password
 					},
-					timeout: timeout
+					timeout: timeout,
+					strictSSL: useStrictSSL
 				}, this.callBack);
 			}
 			else {
@@ -35,7 +37,8 @@ export module Engine{
           					'content-type' : contentType
         				},
 					body: body,
-					timeout: timeout
+					timeout: timeout,
+					strictSSL: useStrictSSL
 				}, this.callBack.bind(this));
 			}
 		}

--- a/restCallBuildTask/main.ts
+++ b/restCallBuildTask/main.ts
@@ -13,6 +13,7 @@ class Main{
             outputFilePath = tl.getPathInput("outputFilePath", false);
         }
 
+        let allowInvalidSSLCertificate = tl.getBoolInput('allowInvalidSSLCertificate', true)
         let webServiceEndpoint = tl.getInput('webserviceEndpoint', true);
         let relativeUrl = tl.getInput('relativeUrl', false);
         let webServiceEndpointUrl = tl.getEndpointUrl(webServiceEndpoint, false);
@@ -43,7 +44,7 @@ class Main{
 
         let contentType = tl.getInput('contentType', true);
 
-        new Engine.RestCall(saveResponseToFile, outputFilePath).call(finalUrl, httpVerb, body, useBasicAuthentication, webServiceEndpointUsername, webServiceEndpointPassword, contentType, timeoutValue);
+        new Engine.RestCall(saveResponseToFile, outputFilePath).call(finalUrl, httpVerb, body, useBasicAuthentication, webServiceEndpointUsername, webServiceEndpointPassword, contentType, timeoutValue, allowInvalidSSLCertificate);
     }
 }
 

--- a/restCallBuildTask/task.json
+++ b/restCallBuildTask/task.json
@@ -90,6 +90,14 @@
       "required": true,
       "visibleRule": "saveResponseToFile = true",
       "helpMarkDown": "Output file path to write response into."
+    },
+    {
+      "name": "allowInvalidSSLCertificate",
+      "type": "boolean",
+      "label": "Allow invalid SSL Certificate?",
+      "defaultValue": false,
+      "required": true,
+      "helpMarkDown": "Do you want to call a URL that has an invalid SSL certificate?"
     }
   ],
   "execution": {


### PR DESCRIPTION
When an api call is to a machine that has a self-signed certificate, this checkbox will allow the call to set strictSSL to false. 